### PR TITLE
To use this as a driver module

### DIFF
--- a/i2c_bme280.c
+++ b/i2c_bme280.c
@@ -29,8 +29,8 @@ THE SOFTWARE.
 
 #include <math.h>
 
-#include "../include/driver/i2c_bme280.h"
-#include "driver/i2c.h"
+#include "i2c_bme280.h"
+#include "../i2c/i2c.h"
 
 uint16_t calib_dig_T1;
  int16_t calib_dig_T2;


### PR DESCRIPTION
After changing the path, you can do a git clone to drivers/esp8266_i2c_bme280 and it will compile without changing the path.
